### PR TITLE
1.10.0: Don't hard-depend on gConfig, support CodeEditor

### DIFF
--- a/replylinks.js
+++ b/replylinks.js
@@ -84,7 +84,7 @@ if ($G.getMediaWikiConfig('wgUserLanguage') in $G.i18n)
 }
 $G.i18n = $G.i18n[$G.Lang];
 
-/** Configurable by users. */
+/** Configurable by users (and default when `gConfig` is not available). */
 $G.options = {
 	boolAddSignature: true,
 };
@@ -620,7 +620,7 @@ $G.getElementsByTagNames = function (list, obj)
 // gConfig init
 mw.hook('userjs.gConfig.ready').add(function (gConfig) {
 	let userConfig = new UserConfig(gConfig);
-	$G.prepareConfig(userConfig);
+	$G.prepareConfig(userConfig); // fires 'userjs.replylinks.configReady'
 });
 
 //
@@ -634,10 +634,12 @@ if (location.search.indexOf('newsectionname=') > 0
 	&& $G.getMediaWikiConfig('wgCanonicalNamespace')=='User_talk')
 {
 	$.when($.ready, mw.loader.using('jquery.textSelection')).done(function () {
+		// init after config if gConfig is available
 		if (mw.loader.getState('ext.gadget.gConfig') !== null) {
 			mw.hook('userjs.replylinks.configReady').add(function(){
 				$G.autoNewSectionInit();
 			});
+		// init directly using default config
 		} else {
 			$G.autoNewSectionInit();
 		}

--- a/replylinks.js
+++ b/replylinks.js
@@ -43,7 +43,7 @@ oRepLinks.version = oRepLinks.ver = '{version}';
 // i18n
 oRepLinks.i18n = {'':''
 	,'en' : {'':''
-		,'std prefix'        : 'Re:'   // standard prefix to a replay
+		,'std prefix'        : 'Re:'   // standard prefix to a reply
 		,'no section prefix' : 'Ad:'   // prefix shown when a section header was not found
 		,'reply link text'   : 'reply'
 	}
@@ -204,7 +204,7 @@ $G.autoNewSectionInit = function()
 		{
 			let content = (this.options.boolAddSignature) ? data.content + '\n--'+'~'+'~'+'~'+'~' : data.content;
 			// link + signature
-			elInput.value = content;
+			$(elInput).textSelection('setContents', content);
 		}
 
 		// setup post-save action(s)
@@ -633,10 +633,14 @@ mw.hook('userjs.gConfig.ready').add(function (gConfig) {
 if (location.search.indexOf('newsectionname=') > 0 
 	&& $G.getMediaWikiConfig('wgCanonicalNamespace')=='User_talk')
 {
-	$(function(){
-		mw.hook('userjs.replylinks.configReady').add(function(){
+	$.when($.ready, mw.loader.using('jquery.textSelection')).done(function () {
+		if (mw.loader.getState('ext.gadget.gConfig') !== null) {
+			mw.hook('userjs.replylinks.configReady').add(function(){
+				$G.autoNewSectionInit();
+			});
+		} else {
 			$G.autoNewSectionInit();
-		});
+		}
 	});
 }
 // add links

--- a/version.mjs
+++ b/version.mjs
@@ -1,5 +1,5 @@
 let version = '1.10.0';
-let info = 'Optional signature; fix';
+let info = `Don't hard-depend on gConfig, support CodeEditor`;
 export {
 	version,
 	info,

--- a/version.mjs
+++ b/version.mjs
@@ -1,4 +1,4 @@
-let version = '1.9.1';
+let version = '1.10.0';
 let info = 'Optional signature; fix';
 export {
 	version,


### PR DESCRIPTION
Makes this tool work (again) on wikis that load it from upstream plwiki sources, e.g. see [pl:wikt:MediaWiki:Gadget-replylinks-local.js](https://pl.wiktionary.org/wiki/MediaWiki:Gadget-replylinks-local.js). Incidentally, adds support for syntax highlighting mode on WikiEditor 2010.